### PR TITLE
Require node in package.json engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "gradestats-app",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "^14 || ^12"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
Next's requirements needs either node v.12 or 14, this sets the same requirements in package.json, which should then require these versions. This is needed by Oryx, as part of the azure deployment, else it uses Node 10.