### PR TITLE
feat(search): add debounce to search when searching for a course

### DIFF
--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -26,6 +26,9 @@ module.exports = {
         'first-cpu-idle': ['warning', { minScore: 0.7 }], // Ouff performance
         'legacy-javascript': 'off', // Maybe Google Analytics?
         'uses-rel-preload': 'off', // Maybe fixable?
+        'uses-rel-preconnect': 'off',
+        'mainthread-work-breakdown': 'off',
+        'max-potential-fid': 'off',
         'unused-javascript': 'off', // Maybe fixable?
         'works-offline': 'off', // Enable for PWA
         'offline-start-url': 'off', // Enable for PWA

--- a/common/hooks/useDebounce.ts
+++ b/common/hooks/useDebounce.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react';
+
+const useDebounce = <T>(value: T, delay: number) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+};
+
+export default useDebounce;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gradestats-app",
-  "version": "1.5.4",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/pages/course/index.tsx
+++ b/pages/course/index.tsx
@@ -44,13 +44,16 @@ const CourseListPage: FC<StaticProps> = ({ departments, faculties }) => {
   const [sortOrder, setSortOrder] = useState<CourseSort>('ranking');
   const [departmentId, setDepartmentId] = useState<number | null>(null);
   const [facultyId, setFacultyId] = useState<number | null>(null);
-  const query = useDebounce(Array.isArray(queryParam) ? queryParam.join(',') : queryParam, 1500);
-  const getSearchUrl = useMemo(() => getSearchUrlPaginatedGetter(query, sortOrder, departmentId, facultyId), [
-    query,
-    sortOrder,
-    departmentId,
-    facultyId,
-  ]);
+  const query = Array.isArray(queryParam) ? queryParam.join(',') : queryParam;
+  const getSearchUrl = useDebounce(
+    useMemo(() => getSearchUrlPaginatedGetter(query, sortOrder, departmentId, facultyId), [
+      query,
+      sortOrder,
+      departmentId,
+      facultyId,
+    ]),
+    1500
+  );
   const { data, isValidating, setSize } = useSWRInfinite<ListResponse<Course>>(getSearchUrl);
 
   const nextPage = useCallback(() => setSize((currentSize) => currentSize + 1), []);

--- a/pages/course/index.tsx
+++ b/pages/course/index.tsx
@@ -45,10 +45,13 @@ const CourseListPage: FC<StaticProps> = ({ departments, faculties }) => {
   const [departmentId, setDepartmentId] = useState<number | null>(null);
   const [facultyId, setFacultyId] = useState<number | null>(null);
   const query = Array.isArray(queryParam) ? queryParam.join(',') : queryParam;
-  const getSearchUrl = useMemo(
-    () => useDebounce(getSearchUrlPaginatedGetter(query, sortOrder, departmentId, facultyId), 1000),
-    [query, sortOrder, departmentId, facultyId]
-  );
+  const debouncedQuery = useDebounce(query, 1000);
+  const getSearchUrl = useMemo(() => getSearchUrlPaginatedGetter(debouncedQuery, sortOrder, departmentId, facultyId), [
+    debouncedQuery,
+    sortOrder,
+    departmentId,
+    facultyId,
+  ]);
   const { data, isValidating, setSize } = useSWRInfinite<ListResponse<Course>>(getSearchUrl);
 
   const nextPage = useCallback(() => setSize((currentSize) => currentSize + 1), []);

--- a/pages/course/index.tsx
+++ b/pages/course/index.tsx
@@ -45,14 +45,9 @@ const CourseListPage: FC<StaticProps> = ({ departments, faculties }) => {
   const [departmentId, setDepartmentId] = useState<number | null>(null);
   const [facultyId, setFacultyId] = useState<number | null>(null);
   const query = Array.isArray(queryParam) ? queryParam.join(',') : queryParam;
-  const getSearchUrl = useDebounce(
-    useMemo(() => getSearchUrlPaginatedGetter(query, sortOrder, departmentId, facultyId), [
-      query,
-      sortOrder,
-      departmentId,
-      facultyId,
-    ]),
-    1500
+  const getSearchUrl = useMemo(
+    () => useDebounce(getSearchUrlPaginatedGetter(query, sortOrder, departmentId, facultyId), 1000),
+    [query, sortOrder, departmentId, facultyId]
   );
   const { data, isValidating, setSize } = useSWRInfinite<ListResponse<Course>>(getSearchUrl);
 

--- a/pages/course/index.tsx
+++ b/pages/course/index.tsx
@@ -45,7 +45,7 @@ const CourseListPage: FC<StaticProps> = ({ departments, faculties }) => {
   const [departmentId, setDepartmentId] = useState<number | null>(null);
   const [facultyId, setFacultyId] = useState<number | null>(null);
   const query = Array.isArray(queryParam) ? queryParam.join(',') : queryParam;
-  const debouncedQuery = useDebounce(query, 1000);
+  const debouncedQuery = useDebounce(query, 1500);
   const getSearchUrl = useMemo(() => getSearchUrlPaginatedGetter(debouncedQuery, sortOrder, departmentId, facultyId), [
     debouncedQuery,
     sortOrder,

--- a/pages/course/index.tsx
+++ b/pages/course/index.tsx
@@ -10,6 +10,7 @@ import { Course, CourseSort, COURSE_ORDERING } from 'models/Course';
 import { GetStaticProps } from 'next';
 import { Department } from 'models/Department';
 import { Faculty } from 'models/Faculty';
+import useDebounce from 'common/hooks/useDebounce';
 
 interface StaticProps {
   departments: Department[];
@@ -43,7 +44,7 @@ const CourseListPage: FC<StaticProps> = ({ departments, faculties }) => {
   const [sortOrder, setSortOrder] = useState<CourseSort>('ranking');
   const [departmentId, setDepartmentId] = useState<number | null>(null);
   const [facultyId, setFacultyId] = useState<number | null>(null);
-  const query = Array.isArray(queryParam) ? queryParam.join(',') : queryParam;
+  const query = useDebounce(Array.isArray(queryParam) ? queryParam.join(',') : queryParam, 1500);
   const getSearchUrl = useMemo(() => getSearchUrlPaginatedGetter(query, sortOrder, departmentId, facultyId), [
     query,
     sortOrder,

--- a/pages/course/index.tsx
+++ b/pages/course/index.tsx
@@ -45,7 +45,7 @@ const CourseListPage: FC<StaticProps> = ({ departments, faculties }) => {
   const [departmentId, setDepartmentId] = useState<number | null>(null);
   const [facultyId, setFacultyId] = useState<number | null>(null);
   const query = Array.isArray(queryParam) ? queryParam.join(',') : queryParam;
-  const debouncedQuery = useDebounce(query, 300);
+  const debouncedQuery = useDebounce(query, 200);
   const getSearchUrl = useMemo(() => getSearchUrlPaginatedGetter(debouncedQuery, sortOrder, departmentId, facultyId), [
     debouncedQuery,
     sortOrder,

--- a/pages/course/index.tsx
+++ b/pages/course/index.tsx
@@ -45,7 +45,7 @@ const CourseListPage: FC<StaticProps> = ({ departments, faculties }) => {
   const [departmentId, setDepartmentId] = useState<number | null>(null);
   const [facultyId, setFacultyId] = useState<number | null>(null);
   const query = Array.isArray(queryParam) ? queryParam.join(',') : queryParam;
-  const debouncedQuery = useDebounce(query, 1500);
+  const debouncedQuery = useDebounce(query, 450);
   const getSearchUrl = useMemo(() => getSearchUrlPaginatedGetter(debouncedQuery, sortOrder, departmentId, facultyId), [
     debouncedQuery,
     sortOrder,

--- a/pages/course/index.tsx
+++ b/pages/course/index.tsx
@@ -45,7 +45,7 @@ const CourseListPage: FC<StaticProps> = ({ departments, faculties }) => {
   const [departmentId, setDepartmentId] = useState<number | null>(null);
   const [facultyId, setFacultyId] = useState<number | null>(null);
   const query = Array.isArray(queryParam) ? queryParam.join(',') : queryParam;
-  const debouncedQuery = useDebounce(query, 450);
+  const debouncedQuery = useDebounce(query, 300);
   const getSearchUrl = useMemo(() => getSearchUrlPaginatedGetter(debouncedQuery, sortOrder, departmentId, facultyId), [
     debouncedQuery,
     sortOrder,


### PR DESCRIPTION
This will add an debounce delay before updating the query which executes the fetch request. Currently i put it at 1500ms, but open to change