### PR TITLE
feat(reports): handle reports with lambda function

### DIFF
--- a/common/api/reports.ts
+++ b/common/api/reports.ts
@@ -1,4 +1,3 @@
-import { getReportListApiUrl } from '../urls';
 import { requestsWithAuth } from 'common/requests';
 
 interface Data {
@@ -13,6 +12,6 @@ export const requestCreateReport = async ({ description, course, contactEmail }:
     course,
     contact_email: contactEmail,
   };
-  const response = await requestsWithAuth.post(getReportListApiUrl(), data);
+  const response = await requestsWithAuth.post('https://m9z5uzxy1i.execute-api.eu-west-1.amazonaws.com/mail', data);
   return response;
 };


### PR DESCRIPTION
Changelog:
- Let sending feedback mails be handled by a lambda function (aws) instead of gradestats
- POSTs to an api gateway that triggers a lambda function

Makes it so if the backend is down feedback can still be sent

Lambda function: gradestats_mail_sender on eu-west-1 on dotkom account
https://github.com/dotkom/terraform-monorepo/pull/103#partial-pull-merging
